### PR TITLE
Fixed: styled-components@4.x.x Allowing Interpolation function's outp…

### DIFF
--- a/definitions/npm/styled-components_v4.x.x/flow_v0.75.x-/styled-components_v4.x.x.js
+++ b/definitions/npm/styled-components_v4.x.x/flow_v0.75.x-/styled-components_v4.x.x.js
@@ -3,7 +3,7 @@
 declare module 'styled-components' {
 
   declare export type Interpolation =
-                                    | (<P: {}>(executionContext: P) => string)
+                                    | (<P: {}>(executionContext: P) => string | number)
                                     | CSSRules
                                     | KeyFrames
                                     | string


### PR DESCRIPTION
…ut to be numbers.

For styled-components' interpolation, it supports different types of representations like `string`, `numbers`, `(<P: {}>(executionContext: P) => string)`. But for the function one, it currently accept `string` as output only. I am not sure if there are any reason why it works in this way.

This is working:

For example, here's the theme for the application.

```jsx
const theme = {
    width: '400',
    height: 400
};

ReactDOM.render(
    <ThemeProvider theme={theme}>
        /* ...... */
    </ThemeProvider>
);
```

To consume the theme's values:

```js
const ExampleComponent = styled.div`
   width: ${({theme}) => theme.width}px; // this works
   height: ${({theme}) => theme.height}px; // this should also work
`;
```

I can only say this is totally making sense and works on my cases every time. I tried to find out this usage in documentation to prove it on [styled-components.com](url), the [github page](https://github.com/styled-components/styled-components/) and the testings but I can't find it out yet unfortunately.

I wonder if there is anyone who can find out this usage in the document please.
